### PR TITLE
[readme] Fix README.md code sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ npm install --save safe-regex-test
 var regexTester = require('safe-regex-test');
 var assert = require('assert');
 
-var tester = regexTester('a');
+var tester = regexTester(/a/);
 assert.ok(tester('a'));
-assert.notOk(tester('b'));
+assert.ok(!tester('b'));
 ```
 
 ## Tests


### PR DESCRIPTION
This commit addresses two `TypeError`s in the example in `README.md`.

1. The `regexTester`'s argument should be a `RegExp` and not a string.
2. There is no such function `notOk` in Node.js' built-in `assert` module. Instead, the `ok` function is used with a negation.

Fixes #3.