### PR TITLE
[readme] Improve failed tester example

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ var assert = require('assert');
 
 var tester = regexTester(/a/);
 assert.ok(tester('a'));
-assert.ok(!tester('b'));
+assert.strictEqual(tester('b'), false);
 ```
 
 ## Tests


### PR DESCRIPTION
Improve the example in the README where `tester` returns `false`, as per the discussion on https://github.com/ljharb/safe-regex-test/pull/4#discussion_r2662500774

Relates to #3.